### PR TITLE
Fix issue with error "AlreadyExists"

### DIFF
--- a/lib/kuber_kit/image_compiler/image_builder.rb
+++ b/lib/kuber_kit/image_compiler/image_builder.rb
@@ -18,9 +18,6 @@ class KuberKit::ImageCompiler::ImageBuilder
 
     build_result = docker_commands.build(shell, build_dir, build_options)
 
-    version_tag = version_tag_builder.get_version
-    docker_commands.tag(shell, image.registry_url, version_tag)
-
     if image.registry.remote?
       docker_commands.tag(shell, image.registry_url, image.remote_registry_url)
       docker_commands.push(shell, image.remote_registry_url)

--- a/lib/kuber_kit/shell/commands/docker_commands.rb
+++ b/lib/kuber_kit/shell/commands/docker_commands.rb
@@ -6,8 +6,8 @@ class KuberKit::Shell::Commands::DockerCommands
     shell.exec!(%Q{docker image build #{build_dir} #{args_list}}, merge_stderr: true)
   end
 
-  def tag(shell, image_name, tag_name)
-    shell.exec!(%Q{docker tag #{image_name} #{tag_name}}, merge_stderr: true)
+  def tag(shell, current_tag_name, new_tag_name)
+    shell.exec!(%Q{docker tag #{current_tag_name} #{new_tag_name}}, merge_stderr: true)
   end
 
   def push(shell, tag_name)

--- a/lib/kuber_kit/version.rb
+++ b/lib/kuber_kit/version.rb
@@ -1,3 +1,3 @@
 module KuberKit
-  VERSION = "1.3.9"
+  VERSION = "1.3.10"
 end

--- a/spec/kuber_kit/image_compiler/image_builder_spec.rb
+++ b/spec/kuber_kit/image_compiler/image_builder_spec.rb
@@ -23,15 +23,9 @@ RSpec.describe KuberKit::ImageCompiler::ImageBuilder do
     subject.build(shell, image, "/tmp/build/example")
   end
 
-  it "adds tag with version if registry is not remote" do
-    expect(subject.docker_commands).to receive(:tag).with(shell, "default/example:latest", "202010.202010")
-    subject.build(shell, image, "/tmp/build/remote_image")
-  end
-
   it "adds tag with remote registry url and version if registry is remote" do
     remote_image = test_helper.remote_image(:remote_image, "http://test.com")
 
-    expect(subject.docker_commands).to receive(:tag).with(shell, "remote/remote_image:latest", "202010.202010")
     expect(subject.docker_commands).to receive(:tag).with(shell, "remote/remote_image:latest", "http://test.com/remote/remote_image:latest")
     subject.build(shell, remote_image, "/tmp/build/remote_image")
   end


### PR DESCRIPTION
Too many errors like 'AlreadyExists: image "docker.io/library/20251127.115449:latest": already exists' during simultaneous building images for large contexts

Docker tag is generated from 'Time.now.strftime' and produce identical tags like "20251127.115449:latest" for different images 
