### PR TITLE
docs: fix typos in debug and error messages

### DIFF
--- a/lib/kuber_kit/actions/service_deployer.rb
+++ b/lib/kuber_kit/actions/service_deployer.rb
@@ -118,7 +118,7 @@ class KuberKit::Actions::ServiceDeployer
   private
     def deploy_simultaneously(service_names, deployment_result)
       unless deployment_result.succeeded?
-        ui.print_debug("ServiceDeployer", "Deploymet already failed. Canceling: #{service_names.inspect}")
+        ui.print_debug("ServiceDeployer", "Deployment already failed. Canceling: #{service_names.inspect}")
         return
       end
 

--- a/lib/kuber_kit/service_deployer/strategies/docker.rb
+++ b/lib/kuber_kit/service_deployer/strategies/docker.rb
@@ -29,7 +29,7 @@ class KuberKit::ServiceDeployer::Strategies::Docker < KuberKit::ServiceDeployer:
     strategy_options = service.attribute(:deployer, default: {})
     unknown_options  = strategy_options.keys.map(&:to_sym) - STRATEGY_OPTIONS
     if unknown_options.any?
-      raise KuberKit::Error, "Unknow options for deploy strategy: #{unknown_options}. Available options: #{STRATEGY_OPTIONS}"
+      raise KuberKit::Error, "Unknown options for deploy strategy: #{unknown_options}. Available options: #{STRATEGY_OPTIONS}"
     end
     
     namespace       = strategy_options.fetch(:namespace, nil)

--- a/lib/kuber_kit/service_deployer/strategies/kubernetes.rb
+++ b/lib/kuber_kit/service_deployer/strategies/kubernetes.rb
@@ -26,7 +26,7 @@ class KuberKit::ServiceDeployer::Strategies::Kubernetes < KuberKit::ServiceDeplo
     strategy_options = service.attribute(:deployer, default: {})
     unknown_options  = strategy_options.keys.map(&:to_sym) - STRATEGY_OPTIONS
     if unknown_options.any?
-      raise KuberKit::Error, "Unknow options for deploy strategy: #{unknown_options}. Available options: #{STRATEGY_OPTIONS}"
+      raise KuberKit::Error, "Unknown options for deploy strategy: #{unknown_options}. Available options: #{STRATEGY_OPTIONS}"
     end
     
     resource_type = strategy_options.fetch(:resource_type, "deployment")


### PR DESCRIPTION
## Summary

Fix 3 typos in user-facing strings:

- **lib/kuber_kit/actions/service_deployer.rb**: "Deploymet" → "Deployment" in debug output
- **lib/kuber_kit/service_deployer/strategies/docker.rb**: "Unknow" → "Unknown" in error message
- **lib/kuber_kit/service_deployer/strategies/kubernetes.rb**: "Unknow" → "Unknown" in error message

String-only changes — no logic or API changes.